### PR TITLE
feat: Implement early exit RAG

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -15,9 +15,20 @@ class QueryRequest(BaseModel):
 @app.post("/ask")
 def ask_query(request: QueryRequest):
     # Step 1: Retrieve documents based on the question
-    context = retrieve_documents(request.question)
+    retrieved_results = retrieve_documents(request.question)  # Now a list of (doc, score)
 
-    # Step 2: Generate an answer using the LLM and the context
-    answer = generate_response(request.task, request.question, context)
+    EARLY_EXIT_THRESHOLD = 0.2
 
-    return {"answer": answer}
+    # Check for early exit condition
+    if retrieved_results and retrieved_results[0][1] < EARLY_EXIT_THRESHOLD:
+        top_document_text = retrieved_results[0][0]
+        return {"answer": top_document_text, "source": "retrieval (early exit)"}
+    else:
+        # Extract document texts to form context
+        document_texts = [result[0] for result in retrieved_results]
+        context = "\n\n".join(document_texts)
+
+        # Step 2: Generate an answer using the LLM and the context
+        answer = generate_response(request.task, request.question, context)
+
+        return {"answer": answer, "source": "generation"}

--- a/backend/retrieval.py
+++ b/backend/retrieval.py
@@ -43,8 +43,11 @@ class DocumentRetriever:
         """
         query_embedding = self.embedding_model.encode([query], convert_to_numpy=True)
         distances, indices = self.index.search(query_embedding, top_k)
-        retrieved_docs = [self.documents[i] for i in indices[0]]
-        return "\n\n".join(retrieved_docs)
+        # Create a list of (document, score) tuples
+        retrieved_docs_with_scores = []
+        for i, doc_index in enumerate(indices[0]):
+            retrieved_docs_with_scores.append((self.documents[doc_index], distances[0][i]))
+        return retrieved_docs_with_scores
 
 
 # Initialize once at server start
@@ -54,5 +57,6 @@ retriever.embed_documents()
 retriever.build_faiss_index()
 
 # This function is imported in app.py
-def retrieve_documents(query: str) -> str:
+def retrieve_documents(query: str) -> list[tuple[str, float]]:
+    # Now returns a list of (document, score) tuples
     return retriever.retrieve(query)


### PR DESCRIPTION
I've added an early exit mechanism to the RAG pipeline.

- If a retrieved document has a similarity score (L2 distance) below 0.2 with your query, I'll return this document directly, bypassing the generation model.
- `retrieval.py` was updated to provide similarity scores alongside documents.
- `app.py` was updated to include the early exit decision logic.

Note: Due to persistent environment issues ('No space left on device'), I couldn't execute the planned automated tests and benchmarks for this feature. The effectiveness of the 0.2 threshold and the overall performance/quality impact of the early exit require further verification once the environment is stable. The generated test script is available at `test_early_exit.py`.